### PR TITLE
[Exercise/5.2] Add integration test for signup page

### DIFF
--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -10,4 +10,9 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', about_path
     assert_select 'a[href=?]', contact_path
   end
+
+  test 'sign-up page' do
+    get signup_path
+    assert_select 'title', 'Sign up | Ruby on Rails Tutorial Sample App'
+  end
 end


### PR DESCRIPTION
Add a test that verifies the rendered `/signup` page has the correct title.
