### PR TITLE
[Exercise/5.3] Use helper methods in tests

### DIFF
--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class ApplicationHelperTest < ActionView::TestCase
+  test 'full title helper' do
+    assert_equal full_title, 'Ruby on Rails Tutorial Sample App'
+    assert_equal full_title('Help'), 'Help | Ruby on Rails Tutorial Sample App'
+  end
+end
+p

--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -9,5 +9,7 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
     assert_select 'a[href=?]', help_path
     assert_select 'a[href=?]', about_path
     assert_select 'a[href=?]', contact_path
+    get signup_path
+    assert_select 'title', full_title('Sign up')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,5 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  include ApplicationHelper
 end


### PR DESCRIPTION
This exercise demonstrates how we can use helper methods in writing tests.
Since tests using a helper method does not verify the behavior of the helper method itself, we need unit tests for the helper method.
