### PR TITLE
[Exercise/7.1] Add `size` optional parameter to `gravatar_for`

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,7 +1,8 @@
 module UsersHelper
-  def gravatar_for(user)
+  def gravatar_for(user, options = {})
     gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}"
+    size = options[:size] || 80
+    gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
     image_tag(gravatar_url, alt: user.name, class: 'gravatar')
   end
 end


### PR DESCRIPTION
`gravatar_for` now accepts optional argument `size`, which specifies the size of resulting gravatar image.

The example on the tutorial defines optional arguments as:

``` ruby
def gravatar_for(user, options = { size: 80 })
  size = options[:size]
```

in order to specify the default value (of `80`) for the `size` argument. This idea does not work with a usage as `gravatar_for(user, {})`. Therefore in this PR, I have defined the default value for optional parameter as:

``` ruby
def gravatar_for(user, options = {})
  size = options[:size] || 80
```
