### PR TITLE
[Exercise/7.2] Update test for invalid signup information

### DIFF
--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -9,6 +9,8 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                password: 'foo', password_confirmation: 'bar' }
     end
     assert_template 'users/new'
+    assert_select 'div#error_explanation'
+    assert_select 'div.field_with_errors'
   end
 
   test 'valid signup information' do


### PR DESCRIPTION
This PR adds assertions to check that validation errors on sign-up are displayed to the user.
