### PR TITLE
[Exercise/7.3-4] Refactor and add test for post-signup flash message

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <%= content_tag(:div, message, class: "flash_message alert alert-#{message_type}") %>
       <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -18,5 +18,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
                                             password: 'password', password_confirmation: 'password' }
     end
     assert_template 'users/show'
+    assert_select 'div.flash_message'
   end
 end


### PR DESCRIPTION
- Add `flash_message` class to the flash messages so that the presence of the messages can be easily tested in integration tests.
- Refactor the view using `content_tag` instead of writing raw HTML tags.
- Update the integration test for valid sign-up process so that it checks the presence of a "Welcome" flash message.

In [Listing 7.33](https://www.railstutorial.org/book/sign_up#_code-flash_test) on the Tutorial, we test that the controller gives a flash after valid sign-up process.
This is, however, insufficient to guarantee the correctness of refactoring of the view ([Listing 7.34](https://www.railstutorial.org/book/sign_up#_code-layout_flash_content_tag)).
Instead, in this PR, we have a test to check that a flash message is correctly rendered.
