### PR TITLE
[Exercies/9.2] Add integration test for site layout

### DIFF
--- a/test/integration/site_layout_test.rb
+++ b/test/integration/site_layout_test.rb
@@ -5,8 +5,36 @@ class SiteLayoutTest < ActionDispatch::IntegrationTest
   test 'layout links' do
     get root_path
     assert_template 'static_pages/home'
+
     assert_select 'a[href=?]', root_path, count: 2
     assert_select 'a[href=?]', help_path
+
+    assert_select 'a[href=?]', login_path
+
+    assert_select 'a[href=?]', users_path, count: 0
+    assert_select 'a[href=?]', logout_path, count: 0
+
+    assert_select 'a[href=?]', about_path
+    assert_select 'a[href=?]', contact_path
+  end
+
+  test 'layout links for logged-in users' do
+    user = users(:michael)
+    log_in_as(user)
+
+    get root_path
+    assert_template 'static_pages/home'
+
+    assert_select 'a[href=?]', root_path, count: 2
+    assert_select 'a[href=?]', help_path
+
+    assert_select 'a[href=?]', login_path, count: 0
+
+    assert_select 'a[href=?]', users_path
+    assert_select 'a[href=?]', user_path(user)
+    assert_select 'a[href=?]', edit_user_path(user)
+    assert_select 'a[href=?]', logout_path
+
     assert_select 'a[href=?]', about_path
     assert_select 'a[href=?]', contact_path
   end


### PR DESCRIPTION
This PR adds an integration test for all the site layout links, including the proper behavior for logged-in and non-logged-in users.
