### PR TITLE
[Exercise/9.3] Add test that checks User.admin is not editable via web

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -56,4 +56,14 @@ class UsersControllerTest < ActionController::TestCase
     end
     assert_redirected_to root_url
   end
+
+  test 'should not allow the admin attribute to be edited via the web' do
+    log_in_as(@other_user)
+    assert_not @other_user.admin?
+    patch :update, id: @other_user,
+          user: {name: 'TESTNAME', admin: '1'}
+    @other_user.reload
+    assert_equal 'TESTNAME', @other_user.name
+    assert_not @other_user.admin?
+  end
 end


### PR DESCRIPTION
This PR adds a test for `UsersController` to check that a direct PATCH request cannot modify the `User.admin` attribute via web.
