### PR TITLE
[Exercise/10.1] Add test for expired reset token

### DIFF
--- a/test/integration/password_resets_test.rb
+++ b/test/integration/password_resets_test.rb
@@ -51,4 +51,18 @@ class PasswordResetsTest < ActionDispatch::IntegrationTest
     assert_select 'div#error_explanation'
   end
 
+  test 'expired token' do
+    get new_password_reset_path
+    post password_resets_path, password_reset: { email: @user.email }
+
+    @user = assigns(:user)
+    @user.update(reset_sent_at: 3.hours.ago)
+
+    patch password_reset_path(@user.reset_token),
+          email: @user.email,
+          user: { password: 'foobar', password_confirmation: 'foobar' }
+    assert_response :redirect
+    follow_redirect!
+    assert_match /expired/i, response.body
+  end
 end


### PR DESCRIPTION
This PR adds an integration test that verifies password reset tokens are correctly expired in 2 hours.
