### PR TITLE
[Exercise/10.2] Hide inactive users from UI

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user, only: [:destroy]
 
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url unless @user.activated
   end
 
   def new

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -30,4 +30,17 @@ class UsersIndexTest < ActionDispatch::IntegrationTest
     get users_path
     assert_select 'a', text: 'delete', count: 0
   end
+
+  test 'index should not include inactive users' do
+    inactive_user, login_user = User.first(2)
+    log_in_as(login_user)
+
+    get users_path
+    assert_select 'a[href=?]', user_path(inactive_user), count: 1
+
+    inactive_user.update(activated: false, activated_at: nil)
+
+    get users_path
+    assert_select 'a[href=?]', user_path(inactive_user), count: 0
+  end
 end

--- a/test/integration/users_show_test.rb
+++ b/test/integration/users_show_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class UsersIndexTest < ActionDispatch::IntegrationTest
+  test 'profile page of an inactive user should not visible' do
+    inactive_user, login_user = User.first(2)
+    log_in_as(login_user)
+
+    get user_path(inactive_user)
+    assert_response :success
+
+    inactive_user.update(activated: false, activated_at: nil)
+
+    get user_path(inactive_user)
+    assert_response :redirect
+  end
+end


### PR DESCRIPTION
This patch hides inactive users (users who have not yet activated their account) from web UI, including the following changes:
- The users index does not include inactive users.
- Profile page of an inactive user is not visible anymore.
