### PR TITLE
[Exercise/11.2] Add test for micropost count on sidebar

### DIFF
--- a/test/integration/microposts_interface_test.rb
+++ b/test/integration/microposts_interface_test.rb
@@ -37,4 +37,18 @@ class MicropostsInterfaceTest < ActionDispatch::IntegrationTest
     get user_path(users(:archer))
     assert_select 'a', text: 'delete', count: 0
   end
+
+  test 'micropost sidebar count' do
+    log_in_as(@user)
+    get root_path
+    assert_match "#{@user.microposts.count} microposts", response.body
+
+    @user = users(:mallory)  # mallory has no microposts
+    log_in_as(@user)
+    get root_path
+    assert_match '0 microposts', response.body
+    @user.microposts.create!(content: 'Hello')
+    get root_path
+    assert_match /1 micropost\b/, response.body
+  end
 end


### PR DESCRIPTION
This PR adds an integration test for the micropost count on the home page for logged-in users, including checks for correctness of the count and word pluralization.
## Conditions to merge
- CI verification
- 1 code review
